### PR TITLE
Group changelog by scope

### DIFF
--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -1,5 +1,6 @@
 require 'fastlane/action'
 require_relative '../helper/semantic_release_helper'
+require 'pry'
 
 module Fastlane
   module Actions
@@ -147,12 +148,10 @@ module Fastlane
           result += style_text(sections[type.to_sym], format, "heading").to_s
           result += "\n"
 
-          commits_by_scope = commits_in_type.group_by { |c| c[:scope].strip }
+          commits_by_scope = commits_in_type.group_by { |c| c[:scope]&.strip || sections[:no_type] }
           commits_by_scope.each do |scope, commits_in_scope|
-            unless scope.nil?
-              formatted_text = style_text("#{scope}:", format, "bold").to_s
-              result += "#{formatted_text}"
-            end
+            subtitle = style_text("#{scope}:", format, "bold").to_s
+            result += "#{subtitle}"
 
             is_single_commit = commits_in_scope.size == 1
             commits_in_scope.each do |commit|

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -132,11 +132,10 @@ module Fastlane
 
       def self.note_builder_grouped(format, commits, version, commit_url, params)
         sections = params[:sections]
-        result = ""
+        lines = []
 
         if params[:display_title] == true
-          result += build_title(version, params)
-          result += "\n\n"
+          sections < build_title(version, params)
         end
 
         commits_by_type = commits.group_by { |c| c[:type] }
@@ -144,31 +143,24 @@ module Fastlane
           commits_in_type = commits_by_type[type]
           next if commits_in_type.nil? || commits_in_type.size == 0
 
-          result += style_text_grouped(sections[type.to_sym], format, "heading").to_s
-          result += "\n"
+          text = style_text_grouped(sections[type.to_sym], format, "heading").to_s
+          lines < text
 
           commits_by_scope = commits_in_type.group_by { |c| c[:scope]&.strip || sections[:no_type] }
           commits_by_scope.each do |scope, commits_in_scope|
             subtitle = style_text_grouped("#{scope}:", format, "bold").to_s
-            result += "#{subtitle}"
+            lines < "#{subtitle}"
 
             is_single_commit = commits_in_scope.size == 1
             commits_in_scope.each do |commit|
               next if commit[:is_merge]
 
-              result += build_commit_grouped(params, commit, is_single_commit)
+              lines < build_commit_grouped(params, commit, is_single_commit)
             end
-
-            result += "\n"
           end
-
-          result += "\n"
         end
 
-        # Trim any trailing newlines
-        result = result.rstrip!
-
-        result
+        sections.join("\n")
       end
 
       def self.build_commit(params, commit, is_single_commit)

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -1,6 +1,5 @@
 require 'fastlane/action'
 require_relative '../helper/semantic_release_helper'
-require 'pry'
 
 module Fastlane
   module Actions

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -130,8 +130,38 @@ module Fastlane
         result
       end
 
+      def self.validate_sections(sections)
+        # Ensure sections is a hash
+        unless sections.is_a?(Hash)
+          UI.user_error!("sections parameter must be a Hash, got #{sections.class}")
+        end
+
+        # Ensure no_type section exists as it's used as fallback for commits without scope
+        unless sections.key?(:no_type)
+          UI.user_error!("sections parameter must include a :no_type key for commits without scope. " \
+                         "Add 'no_type: \"Other work\"' to your sections configuration.")
+        end
+
+        # Ensure no_type value is not nil or empty
+        if sections[:no_type].nil? || sections[:no_type].to_s.strip.empty?
+          UI.user_error!("sections[:no_type] cannot be nil or empty. " \
+                         "Provide a meaningful section name like 'Other work'.")
+        end
+      end
+
+      def self.normalize_scope(scope, fallback_scope)
+        # Normalize scope by trimming whitespace and handling empty/nil values
+        normalized = scope&.strip
+        if normalized.nil? || normalized.empty?
+          fallback_scope
+        else
+          normalized
+        end
+      end
+
       def self.note_builder_grouped(format, commits, version, commit_url, params)
         sections = params[:sections]
+        validate_sections(sections)
         lines = []
 
         if params[:display_title] == true
@@ -144,26 +174,45 @@ module Fastlane
           commits_in_type = commits_by_type[type]
           next if commits_in_type.nil? || commits_in_type.size == 0
 
+          # Filter out merge commits at the type level first
+          non_merge_commits_in_type = commits_in_type.reject { |commit| commit[:is_merge] }
+          next if non_merge_commits_in_type.empty?
+
           type_text = style_text_grouped(sections[type.to_sym], format, "heading").to_s
           lines << type_text
 
-          commits_by_scope = commits_in_type.group_by { |c| c[:scope]&.strip || sections[:no_type] }
-          commits_by_scope.each do |plain_scope, commits_in_scope|
+          commits_by_scope = non_merge_commits_in_type.group_by { |c| normalize_scope(c[:scope], sections[:no_type]) }
+
+          # Sort scopes to ensure consistent ordering: preserve order of first appearance, but put fallback scope last
+          scope_order = {}
+          non_merge_commits_in_type.each_with_index do |commit, index|
+            scope = normalize_scope(commit[:scope], sections[:no_type])
+            scope_order[scope] ||= index
+          end
+
+          sorted_scopes = commits_by_scope.keys.sort do |a, b|
+            if a == sections[:no_type] && b != sections[:no_type]
+              1  # fallback scope comes last
+            elsif a != sections[:no_type] && b == sections[:no_type]
+              -1  # named scope comes first
+            else
+              scope_order[a] <=> scope_order[b]  # preserve order of first appearance
+            end
+          end
+
+          sorted_scopes.each do |plain_scope|
+            commits_in_scope = commits_by_scope[plain_scope]
             scope = style_text_grouped("#{plain_scope}:", format, "bold").to_s
 
             is_single_commit = commits_in_scope.size == 1
             if is_single_commit
               commit = commits_in_scope.first
-              next if commit[:is_merge]
-
               commit_text = build_commit_grouped(params, commit, is_single_commit)
               lines << "#{scope} #{commit_text}"
             else
               lines << scope
 
               commits_in_scope.each do |commit|
-                next if commit[:is_merge]
-
                 commit_text = build_commit_grouped(params, commit, is_single_commit)
                 lines << commit_text
               end

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -159,6 +159,12 @@ module Fastlane
         end
       end
 
+      def self.normalize_scope_for_grouping(scope)
+        # Normalize scope to lowercase for consistent grouping
+        # This ensures "cache", "Cache", and "CACHE" all group together
+        scope.nil? ? nil : scope.downcase
+      end
+
       def self.note_builder_grouped(format, commits, version, commit_url, params)
         sections = params[:sections]
         validate_sections(sections)
@@ -181,28 +187,38 @@ module Fastlane
           type_text = style_text_grouped(sections[type.to_sym], format, "heading").to_s
           lines << type_text
 
-          commits_by_scope = non_merge_commits_in_type.group_by { |c| normalize_scope(c[:scope], sections[:no_type]) }
-
-          # Sort scopes to ensure consistent ordering: preserve order of first appearance, but put fallback scope last
-          scope_order = {}
-          non_merge_commits_in_type.each_with_index do |commit, index|
-            scope = normalize_scope(commit[:scope], sections[:no_type])
-            scope_order[scope] ||= index
+          # Group commits by normalized scope (lowercase) for consistent grouping
+          # but preserve the original scope for display
+          commits_by_normalized_scope = non_merge_commits_in_type.group_by do |c|
+            normalized = normalize_scope(c[:scope], sections[:no_type])
+            normalize_scope_for_grouping(normalized)
           end
 
-          sorted_scopes = commits_by_scope.keys.sort do |a, b|
-            if a == sections[:no_type] && b != sections[:no_type]
+          # Build a map of normalized scope -> original scope (use first occurrence)
+          normalized_to_original = {}
+          non_merge_commits_in_type.each do |commit|
+            normalized = normalize_scope(commit[:scope], sections[:no_type])
+            normalized_for_grouping = normalize_scope_for_grouping(normalized)
+            normalized_to_original[normalized_for_grouping] ||= normalized
+          end
+
+          # Sort scopes alphabetically, but put fallback scope last
+          sorted_normalized_scopes = commits_by_normalized_scope.keys.sort do |a, b|
+            fallback_normalized = normalize_scope_for_grouping(sections[:no_type])
+            if a == fallback_normalized && b != fallback_normalized
               1  # fallback scope comes last
-            elsif a != sections[:no_type] && b == sections[:no_type]
+            elsif a != fallback_normalized && b == fallback_normalized
               -1  # named scope comes first
             else
-              scope_order[a] <=> scope_order[b]  # preserve order of first appearance
+              a.casecmp(b)  # alphabetical sort (case-insensitive)
             end
           end
 
-          sorted_scopes.each do |plain_scope|
-            commits_in_scope = commits_by_scope[plain_scope]
-            scope = style_text_grouped("#{plain_scope}:", format, "bold").to_s
+          sorted_normalized_scopes.each do |normalized_scope|
+            commits_in_scope = commits_by_normalized_scope[normalized_scope]
+            # Use the original scope for display
+            display_scope = normalized_to_original[normalized_scope]
+            scope = style_text_grouped("#{display_scope}:", format, "bold").to_s
 
             is_single_commit = commits_in_scope.size == 1
             if is_single_commit

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -151,7 +151,7 @@ module Fastlane
 
       def self.normalize_scope(scope, fallback_scope)
         # Normalize scope by trimming whitespace and handling empty/nil values
-        normalized = scope&.strip
+        normalized = scope.nil? ? nil : scope.strip
         if normalized.nil? || normalized.empty?
           fallback_scope
         else

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -162,7 +162,34 @@ module Fastlane
       def self.normalize_scope_for_grouping(scope)
         # Normalize scope to lowercase for consistent grouping
         # This ensures "cache", "Cache", and "CACHE" all group together
-        scope.nil? ? nil : scope.downcase
+        return nil if scope.nil?
+
+        normalized = scope.downcase
+
+        # Map semantically related scopes to a canonical form
+        # "Cleanup" and "Refactor" are grouped together as "refactor"
+        case normalized
+        when /^cleanup/
+          'refactor'
+        when /^refactor/
+          'refactor'
+        when /^any/
+          'any'
+        else
+          normalized
+        end
+      end
+
+      def self.is_semantic_mapping?(scope)
+        # Check if a scope has a semantic mapping (e.g., Cleanup -> refactor)
+        return false if scope.nil?
+        normalized = scope.downcase
+        case normalized
+        when /^cleanup/, /^refactor/, /^any/
+          true
+        else
+          false
+        end
       end
 
       def self.note_builder_grouped(format, commits, version, commit_url, params)
@@ -188,18 +215,30 @@ module Fastlane
           lines << type_text
 
           # Group commits by normalized scope (lowercase) for consistent grouping
-          # but preserve the original scope for display
+          # but preserve the original scope for display (unless it's a semantic mapping)
           commits_by_normalized_scope = non_merge_commits_in_type.group_by do |c|
             normalized = normalize_scope(c[:scope], sections[:no_type])
             normalize_scope_for_grouping(normalized)
           end
 
-          # Build a map of normalized scope -> original scope (use first occurrence)
-          normalized_to_original = {}
+          # Build a map of normalized scope -> display scope
+          # For semantic mappings (Cleanup->refactor, Refactor->refactor), use the canonical form
+          # For other scopes, use the original scope
+          normalized_to_display = {}
           non_merge_commits_in_type.each do |commit|
             normalized = normalize_scope(commit[:scope], sections[:no_type])
             normalized_for_grouping = normalize_scope_for_grouping(normalized)
-            normalized_to_original[normalized_for_grouping] ||= normalized
+
+            # Determine display scope
+            if is_semantic_mapping?(normalized)
+              # This is a semantic mapping (e.g., Cleanup -> refactor)
+              display_scope = normalized_for_grouping
+            else
+              # Use the original scope for display
+              display_scope = normalized
+            end
+
+            normalized_to_display[normalized_for_grouping] ||= display_scope
           end
 
           # Sort scopes alphabetically, but put fallback scope last
@@ -216,8 +255,8 @@ module Fastlane
 
           sorted_normalized_scopes.each do |normalized_scope|
             commits_in_scope = commits_by_normalized_scope[normalized_scope]
-            # Use the original scope for display
-            display_scope = normalized_to_original[normalized_scope]
+            # Use the canonical display scope (from normalize_scope_for_grouping)
+            display_scope = normalized_to_display[normalized_scope]
             scope = style_text_grouped("#{display_scope}:", format, "bold").to_s
 
             is_single_commit = commits_in_scope.size == 1

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -299,7 +299,14 @@ module Fastlane
             default_value: false,
             type: Boolean,
             optional: true
-          )
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :group_by_scope,
+            description: "True if you want to group multiple changes by scope name",
+            default_value: false,
+            type: Boolean,
+            optional: true
+          ),
         ]
       end
 

--- a/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release/actions/conventional_changelog.rb
@@ -192,6 +192,21 @@ module Fastlane
         end
       end
 
+      def self.capitalize_scope(scope)
+        # Capitalize the first letter of the scope for display
+        # Examples: "offline" -> "Offline", "OFFLINE" -> "Offline", "PlaylistRepository" -> "PlaylistRepository"
+        return nil if scope.nil?
+        return scope if scope.empty?
+
+        # If the scope is all uppercase (like "OFFLINE"), convert to title case
+        if scope == scope.upcase && scope.length > 1
+          scope[0].upcase + scope[1..-1].downcase
+        else
+          # Otherwise, just ensure first letter is uppercase
+          scope[0].upcase + scope[1..-1]
+        end
+      end
+
       def self.note_builder_grouped(format, commits, version, commit_url, params)
         sections = params[:sections]
         validate_sections(sections)
@@ -257,7 +272,9 @@ module Fastlane
             commits_in_scope = commits_by_normalized_scope[normalized_scope]
             # Use the canonical display scope (from normalize_scope_for_grouping)
             display_scope = normalized_to_display[normalized_scope]
-            scope = style_text_grouped("#{display_scope}:", format, "bold").to_s
+            # Capitalize the first letter of the scope for display
+            capitalized_scope = capitalize_scope(display_scope)
+            scope = style_text_grouped("#{capitalized_scope}:", format, "bold").to_s
 
             is_single_commit = commits_in_scope.size == 1
             if is_single_commit

--- a/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
+++ b/lib/fastlane/plugin/semantic_release/helper/semantic_release_helper.rb
@@ -7,8 +7,8 @@ module Fastlane
     class SemanticReleaseHelper
       def self.format_patterns
         return {
-          "default" => /^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)/,
-          "angular" => /^(\w*)(?:\((.*)\))?(): (.*)/
+          "default" => /^(docs|fix|feat|chore|style|refactor|perf|test)(?:\((.*)\))?(!?)\: (.*)/i,
+          "angular" => /^(\w*)(?:\((.*)\))?(): (.*)/i
         }
       end
 
@@ -52,7 +52,7 @@ module Fastlane
         }
 
         unless matched.nil?
-          type = matched[1]
+          type = matched[1].downcase
           scope = matched[2]
 
           result[:is_valid] = true

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -1,4 +1,7 @@
 require 'spec_helper'
+require 'pry'
+
+
 
 describe Fastlane::Actions::ConventionalChangelogAction do
   HASH_MARKDOWN = "([short_hash](/long_hash))"
@@ -320,21 +323,20 @@ describe Fastlane::Actions::ConventionalChangelogAction do
                             "- **Scope 1:**\n"\
                             "   - Add a new feature #{HASH_MARKDOWN}\n"\
                             "   - Add another feature #{HASH_MARKDOWN}\n"\
-                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}\n"
+                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}"
 
 
           result = execute_lane_test(group_by_scope: true)
-
           expect(result).to eq(expected_result)
         end
 
         it "should group in Scope 1 multiple commits in plain format" do
           expected_result = "1.0.2 (2019-05-25)\n\n"\
                             "Features:\n"\
-                            "- Scope 2: Add one more feature #{HASH_PLAIN}"
                             "- Scope 1:\n"\
                             "   - Add a new feature #{HASH_PLAIN}\n"\
                             "   - Add another feature #{HASH_PLAIN}\n"\
+                            "- Scope 2: Add one more feature #{HASH_PLAIN}"
 
           result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -378,13 +380,16 @@ describe Fastlane::Actions::ConventionalChangelogAction do
                             "   - Add another feature #{HASH_MARKDOWN}\n"\
                             "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}\n"\
                             "### Bug fixes\n"\
-                            "- **Scope 2:** Add 1 more feature #{HASH_MARKDOWN}"\
+                            "- **Scope 2:** Add 1 more feature #{HASH_MARKDOWN}\n"\
                             "- **Scope 1:**\n"\
                             "   - Add 2 more feature #{HASH_MARKDOWN}\n"\
-                            "   - Add 3 more feature #{HASH_MARKDOWN}\n"\
+                            "   - Add 3 more feature #{HASH_MARKDOWN}"\
 
 
           result = execute_lane_test(group_by_scope: true)
+          puts "RESULT #{result}\n"
+          puts "expected_result #{result}\n"
+
           expect(result).to eq(expected_result)
         end
       end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 require 'pry'
 
-
-
 describe Fastlane::Actions::ConventionalChangelogAction do
   HASH_MARKDOWN = "([short_hash](/long_hash))"
   HASH_PLAIN = "(/long_hash)"
@@ -310,7 +308,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
           commits = [
             commit(type: 'feat', scope: 'Scope 1', title: 'Add a new feature'),
             commit(type: 'feat', scope: 'Scope 1', title: 'Add another feature'),
-            commit(type: 'feat', scope: 'Scope 2', title: 'Add one more feature'),
+            commit(type: 'feat', scope: 'Scope 2', title: 'Add one more feature')
           ]
 
           allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
@@ -325,8 +323,8 @@ describe Fastlane::Actions::ConventionalChangelogAction do
                             "   - Add another feature #{HASH_MARKDOWN}\n"\
                             "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}"
 
-
           result = execute_lane_test(group_by_scope: true)
+
           expect(result).to eq(expected_result)
         end
 
@@ -398,7 +396,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
             commit(type: 'feat', scope: 'Same Scope', title: 'Add a new feature with scope'),
             commit(type: 'feat', title: 'Add a new feature 3'),
             commit(type: 'feat', scope: 'Same Scope', title: 'Add a new feature with scope 2'),
-            commit(type: 'feat', title: 'Add another feature'),
+            commit(type: 'feat', title: 'Add another feature')
           ]
 
           allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::ConventionalChangelogAction do
+  def commit(type, scope, message, author="Jiri Otahal")
+    "#{type}(#{scope}): #{message}|long_hash|short_hash|#{author}|time"
+  end
+
   describe "Conventional Changelog" do
     before do
       Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::CONVENTIONAL_CHANGELOG_ACTION_FORMAT_PATTERN] = Fastlane::Helper::SemanticReleaseHelper.format_patterns["default"]
@@ -287,6 +291,119 @@ describe Fastlane::Actions::ConventionalChangelogAction do
     end
 
     after do
+    end
+
+    describe 'group messages if group_by_scope is true' do
+      before do
+        commits = [
+          commit('feat', 'Scope 1', 'Add a new feature'),
+          commit('feat', 'Scope 1', 'Add another feature'),
+          commit('feat', 'Scope 2', 'Add one more feature')
+        ]
+
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+      end
+
+      it "should hide in markdown format" do
+        expected_result = """### Bug fixes
+        - Scope 1:
+           - Add a new feature([short_hash](/long_hash))
+           - Add another feature([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true)
+
+        expect(result).to eq(expected_result)
+      end
+
+      it "should hide in plain format" do
+        expected_result = """Bug fixes
+        - Scope 1:
+           - Add a new feature ([short_hash](/long_hash))
+           - Add another feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more ([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true, format: 'plain')
+
+        expect(result).to eq(expected_result)
+      end
+
+      it "should hide in slack format" do
+        expected_result = """* Bug fixes *
+        - Scope 1:
+           - Add a new feature ([short_hash](/long_hash))
+           - Add another feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more ([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true, format: 'slack')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    describe 'dont group messages if group_by_scope is false' do
+      before do
+        commits = [
+          commit('feat', 'Scope 1', 'Add a new feature'),
+          commit('feat', 'Scope 1', 'Add another feature'),
+          commit('feat', 'Scope 2', 'Add one more feature')
+        ]
+
+        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+      end
+
+      it "should hide in markdown format" do
+        expected_result = """### Bug fixes
+        - Scope 1:
+           - Add a new feature([short_hash](/long_hash))
+        - Scope 1:
+           - Add another feature([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true)
+
+        expect(result).to eq(expected_result)
+      end
+
+      it "should hide in plain format" do
+        expected_result = """Bug fixes
+        - Scope 1:
+           - Add a new feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add another feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more ([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true, format: 'plain')
+
+        expect(result).to eq(expected_result)
+      end
+
+      it "should hide in slack format" do
+        expected_result = """* Bug fixes *
+        - Scope 1:
+           - Add a new feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add another feature ([short_hash](/long_hash))
+        - Scope 1:
+           - Add one more ([short_hash](/long_hash))
+        """
+
+        result = execute_lane_test(group_by_scope: true, format: 'slack')
+
+        expect(result).to eq(expected_result)
+      end
     end
   end
 end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::ConventionalChangelogAction do
-  def commit(type, scope, message, author="Jiri Otahal")
-    "#{type}(#{scope}): #{message}|long_hash|short_hash|#{author}|time"
+  def commit(type, scope, sub, body='', author="Jiri Otahal")
+    "#{type}(#{scope}): #{sub}|#{body}|long_hash|short_hash|#{author}|time"
   end
 
   describe "Conventional Changelog" do
@@ -306,11 +306,13 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       end
 
       it "should hide in markdown format" do
-        expected_result = """### Bug fixes
-- Scope 1:
-   - Add a new feature([short_hash](/long_hash))
-   - Add another feature([short_hash](/long_hash))
-- Scope 1: Add one more([short_hash](/long_hash))"""
+        expected_result = """# 1.0.2 (2019-05-25)
+
+### Features
+**Scope 1:**
+   - Add a new feature ([short_hash](/long_hash))
+   - Add another feature ([short_hash](/long_hash))
+**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true)
 
@@ -318,11 +320,13 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       end
 
       it "should hide in plain format" do
-        expected_result = """Bug fixes
-- Scope 1:
+        expected_result = """# 1.0.2 (2019-05-25)
+
+Features
+**Scope 1:**
    - Add a new feature ([short_hash](/long_hash))
    - Add another feature ([short_hash](/long_hash))
-- Scope 1: Add one more ([short_hash](/long_hash))"""
+**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -330,11 +334,13 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       end
 
       it "should hide in slack format" do
-        expected_result = """* Bug fixes *
-- Scope 1:
+        expected_result = """# 1.0.2 (2019-05-25)
+
+* Features *
+**Scope 1:**
    - Add a new feature ([short_hash](/long_hash))
    - Add another feature ([short_hash](/long_hash))
-- Scope 1: Add one more ([short_hash](/long_hash))"""
+**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true, format: 'slack')
 

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -387,8 +387,6 @@ describe Fastlane::Actions::ConventionalChangelogAction do
 
 
           result = execute_lane_test(group_by_scope: true)
-          puts "RESULT #{result}\n"
-          puts "expected_result #{result}\n"
 
           expect(result).to eq(expected_result)
         end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -307,7 +307,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
           commits = [
             commit(type: 'feat', scope: 'Scope 1', title: 'Add a new feature'),
             commit(type: 'feat', scope: 'Scope 1', title: 'Add another feature'),
-            commit(type: 'feat', scope: 'Scope 2', title: 'Add one more feature')
+            commit(type: 'feat', scope: 'Scope 2', title: 'Add one more feature'),
           ]
 
           allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
@@ -320,7 +320,8 @@ describe Fastlane::Actions::ConventionalChangelogAction do
                             "- **Scope 1:**\n"\
                             "   - Add a new feature #{HASH_MARKDOWN}\n"\
                             "   - Add another feature #{HASH_MARKDOWN}\n"\
-                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}"
+                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}\n"
+
 
           result = execute_lane_test(group_by_scope: true)
 
@@ -330,10 +331,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in plain format" do
           expected_result = "1.0.2 (2019-05-25)\n\n"\
                             "Features:\n"\
+                            "- Scope 2: Add one more feature #{HASH_PLAIN}"
                             "- Scope 1:\n"\
                             "   - Add a new feature #{HASH_PLAIN}\n"\
                             "   - Add another feature #{HASH_PLAIN}\n"\
-                            "- Scope 2: Add one more feature #{HASH_PLAIN}"
 
           result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -350,6 +351,40 @@ describe Fastlane::Actions::ConventionalChangelogAction do
 
           result = execute_lane_test(group_by_scope: true, format: 'slack')
 
+          expect(result).to eq(expected_result)
+        end
+      end
+
+      context "having scopes and  multiple commits with different types" do
+        before do
+          commits = [
+            commit(type: 'feat', scope: 'Scope 1', title: 'Add a new feature'),
+            commit(type: 'feat', scope: 'Scope 1', title: 'Add another feature'),
+            commit(type: 'feat', scope: 'Scope 2', title: 'Add one more feature'),
+            commit(type: 'fix', scope: 'Scope 2', title: 'Add 1 more feature'),
+            commit(type: 'fix', scope: 'Scope 1', title: 'Add 2 more feature'),
+            commit(type: 'fix', scope: 'Scope 1', title: 'Add 3 more feature')
+          ]
+
+          allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+          allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+        end
+
+        it "should group by type and then by scope" do
+          expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                            "### Features\n"\
+                            "- **Scope 1:**\n"\
+                            "   - Add a new feature #{HASH_MARKDOWN}\n"\
+                            "   - Add another feature #{HASH_MARKDOWN}\n"\
+                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}\n"\
+                            "### Bug fixes\n"\
+                            "- **Scope 2:** Add 1 more feature #{HASH_MARKDOWN}"\
+                            "- **Scope 1:**\n"\
+                            "   - Add 2 more feature #{HASH_MARKDOWN}\n"\
+                            "   - Add 3 more feature #{HASH_MARKDOWN}\n"\
+
+
+          result = execute_lane_test(group_by_scope: true)
           expect(result).to eq(expected_result)
         end
       end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -317,10 +317,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in markdown format" do
           expected_result = "# 1.0.2 (2019-05-25)\n\n"\
                             "### Features\n"\
-                            "**Scope 1:**\n"\
+                            "- **Scope 1:**\n"\
                             "   - Add a new feature #{HASH_MARKDOWN}\n"\
                             "   - Add another feature #{HASH_MARKDOWN}\n"\
-                            "**Scope 2:** Add one more feature #{HASH_MARKDOWN}"
+                            "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}"
 
           result = execute_lane_test(group_by_scope: true)
 
@@ -330,10 +330,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in plain format" do
           expected_result = "1.0.2 (2019-05-25)\n\n"\
                             "Features:\n"\
-                            "Scope 1:\n"\
+                            "- Scope 1:\n"\
                             "   - Add a new feature #{HASH_PLAIN}\n"\
                             "   - Add another feature #{HASH_PLAIN}\n"\
-                            "Scope 2: Add one more feature #{HASH_PLAIN}"
+                            "- Scope 2: Add one more feature #{HASH_PLAIN}"
 
           result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -343,10 +343,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in slack format" do
           expected_result = "*1.0.2 (2019-05-25)*\n\n"\
                             "*Features*\n"\
-                            "*Scope 1:*\n"\
-                            "   - Add a new feature #{HASH_SLACK}\n"\
-                            "   - Add another feature #{HASH_SLACK}\n"\
-                            "*Scope 2:* Add one more feature #{HASH_SLACK}"
+                            "- *Scope 1:*\n"\
+                            "    - Add a new feature #{HASH_SLACK}\n"\
+                            "    - Add another feature #{HASH_SLACK}\n"\
+                            "- *Scope 2:* Add one more feature #{HASH_SLACK}"
 
           result = execute_lane_test(group_by_scope: true, format: 'slack')
 
@@ -370,10 +370,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group multiple commits without scope inside 'Other work' in markdown format" do
           expected_result = "# 1.0.2 (2019-05-25)\n\n"\
                             "### Features\n"\
-                            "**Same Scope:**\n"\
+                            "- **Same Scope:**\n"\
                             "   - Add a new feature with scope #{HASH_MARKDOWN}\n"\
                             "   - Add a new feature with scope 2 #{HASH_MARKDOWN}\n"\
-                            "**Other work:**\n"\
+                            "- **Other work:**\n"\
                             "   - Add a new feature 3 #{HASH_MARKDOWN}\n"\
                             "   - Add another feature #{HASH_MARKDOWN}"
 
@@ -385,10 +385,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in plain format" do
           expected_result = "1.0.2 (2019-05-25)\n\n"\
                             "Features:\n"\
-                            "Same Scope:\n"\
+                            "- Same Scope:\n"\
                             "   - Add a new feature with scope #{HASH_PLAIN}\n"\
                             "   - Add a new feature with scope 2 #{HASH_PLAIN}\n"\
-                            "Other work:\n"\
+                            "- Other work:\n"\
                             "   - Add a new feature 3 #{HASH_PLAIN}\n"\
                             "   - Add another feature #{HASH_PLAIN}"
 
@@ -400,12 +400,12 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         it "should group in Scope 1 multiple commits in slack format" do
           expected_result = "*1.0.2 (2019-05-25)*\n\n"\
                             "*Features*\n"\
-                            "*Same Scope:*\n"\
-                            "   - Add a new feature with scope #{HASH_SLACK}\n"\
-                            "   - Add a new feature with scope 2 #{HASH_SLACK}\n"\
-                            "*Other work:*\n"\
-                            "   - Add a new feature 3 #{HASH_SLACK}\n"\
-                            "   - Add another feature #{HASH_SLACK}"
+                            "- *Same Scope:*\n"\
+                            "    - Add a new feature with scope #{HASH_SLACK}\n"\
+                            "    - Add a new feature with scope 2 #{HASH_SLACK}\n"\
+                            "- *Other work:*\n"\
+                            "    - Add a new feature 3 #{HASH_SLACK}\n"\
+                            "    - Add another feature #{HASH_SLACK}"
 
           result = execute_lane_test(group_by_scope: true, format: 'slack')
 

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -305,42 +305,39 @@ describe Fastlane::Actions::ConventionalChangelogAction do
         allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
       end
 
-      it "should hide in markdown format" do
-        expected_result = """# 1.0.2 (2019-05-25)
-
-### Features
-**Scope 1:**
-   - Add a new feature ([short_hash](/long_hash))
-   - Add another feature ([short_hash](/long_hash))
-**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
+      it "should group in Scope 1 multiple commits in markdown format" do
+        expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                          "### Features\n"\
+                          "**Scope 1:**\n"\
+                          "   - Add a new feature ([short_hash](/long_hash))\n"\
+                          "   - Add another feature ([short_hash](/long_hash))\n"\
+                          "**Scope 2:** Add one more feature ([short_hash](/long_hash))"
 
         result = execute_lane_test(group_by_scope: true)
 
         expect(result).to eq(expected_result)
       end
 
-      it "should hide in plain format" do
-        expected_result = """1.0.2 (2019-05-25)
-
-Features:
-Scope 1:
-   - Add a new feature (/long_hash)
-   - Add another feature (/long_hash)
-Scope 2: Add one more feature (/long_hash)"""
+      it "should group in Scope 1 multiple commits in plain format" do
+        expected_result = "1.0.2 (2019-05-25)\n\n"\
+                          "Features:\n"\
+                          "Scope 1:\n"\
+                          "   - Add a new feature (/long_hash)\n"\
+                          "   - Add another feature (/long_hash)\n"\
+                          "Scope 2: Add one more feature (/long_hash)"
 
         result = execute_lane_test(group_by_scope: true, format: 'plain')
 
         expect(result).to eq(expected_result)
       end
 
-      it "should hide in slack format" do
-        expected_result = """*1.0.2 (2019-05-25)*
-
-*Features*
-*Scope 1:*
-   - Add a new feature (</long_hash|short_hash>)
-   - Add another feature (</long_hash|short_hash>)
-*Scope 2:* Add one more feature (</long_hash|short_hash>)"""
+      it "should group in Scope 1 multiple commits in slack format" do
+        expected_result = "*1.0.2 (2019-05-25)*\n\n"\
+                          "*Features*\n"\
+                          "*Scope 1:*\n"\
+                          "   - Add a new feature (</long_hash|short_hash>)\n"\
+                          "   - Add another feature (</long_hash|short_hash>)\n"\
+                          "*Scope 2:* Add one more feature (</long_hash|short_hash>)"
 
         result = execute_lane_test(group_by_scope: true, format: 'slack')
 

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -320,13 +320,13 @@ describe Fastlane::Actions::ConventionalChangelogAction do
       end
 
       it "should hide in plain format" do
-        expected_result = """# 1.0.2 (2019-05-25)
+        expected_result = """1.0.2 (2019-05-25)
 
-Features
-**Scope 1:**
-   - Add a new feature ([short_hash](/long_hash))
-   - Add another feature ([short_hash](/long_hash))
-**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
+Features:
+Scope 1:
+   - Add a new feature (/long_hash)
+   - Add another feature (/long_hash)
+Scope 2: Add one more feature (/long_hash)"""
 
         result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -334,13 +334,13 @@ Features
       end
 
       it "should hide in slack format" do
-        expected_result = """# 1.0.2 (2019-05-25)
+        expected_result = """*1.0.2 (2019-05-25)*
 
-* Features *
-**Scope 1:**
-   - Add a new feature ([short_hash](/long_hash))
-   - Add another feature ([short_hash](/long_hash))
-**Scope 2:** Add one more feature ([short_hash](/long_hash))"""
+*Features*
+*Scope 1:*
+   - Add a new feature (</long_hash|short_hash>)
+   - Add another feature (</long_hash|short_hash>)
+*Scope 2:* Add one more feature (</long_hash|short_hash>)"""
 
         result = execute_lane_test(group_by_scope: true, format: 'slack')
 

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -307,12 +307,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
 
       it "should hide in markdown format" do
         expected_result = """### Bug fixes
-        - Scope 1:
-           - Add a new feature([short_hash](/long_hash))
-           - Add another feature([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more([short_hash](/long_hash))
-        """
+- Scope 1:
+   - Add a new feature([short_hash](/long_hash))
+   - Add another feature([short_hash](/long_hash))
+- Scope 1: Add one more([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true)
 
@@ -321,12 +319,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
 
       it "should hide in plain format" do
         expected_result = """Bug fixes
-        - Scope 1:
-           - Add a new feature ([short_hash](/long_hash))
-           - Add another feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more ([short_hash](/long_hash))
-        """
+- Scope 1:
+   - Add a new feature ([short_hash](/long_hash))
+   - Add another feature ([short_hash](/long_hash))
+- Scope 1: Add one more ([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true, format: 'plain')
 
@@ -335,70 +331,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
 
       it "should hide in slack format" do
         expected_result = """* Bug fixes *
-        - Scope 1:
-           - Add a new feature ([short_hash](/long_hash))
-           - Add another feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more ([short_hash](/long_hash))
-        """
-
-        result = execute_lane_test(group_by_scope: true, format: 'slack')
-
-        expect(result).to eq(expected_result)
-      end
-    end
-
-    describe 'dont group messages if group_by_scope is false' do
-      before do
-        commits = [
-          commit('feat', 'Scope 1', 'Add a new feature'),
-          commit('feat', 'Scope 1', 'Add another feature'),
-          commit('feat', 'Scope 2', 'Add one more feature')
-        ]
-
-        allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
-        allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
-      end
-
-      it "should hide in markdown format" do
-        expected_result = """### Bug fixes
-        - Scope 1:
-           - Add a new feature([short_hash](/long_hash))
-        - Scope 1:
-           - Add another feature([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more([short_hash](/long_hash))
-        """
-
-        result = execute_lane_test(group_by_scope: true)
-
-        expect(result).to eq(expected_result)
-      end
-
-      it "should hide in plain format" do
-        expected_result = """Bug fixes
-        - Scope 1:
-           - Add a new feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add another feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more ([short_hash](/long_hash))
-        """
-
-        result = execute_lane_test(group_by_scope: true, format: 'plain')
-
-        expect(result).to eq(expected_result)
-      end
-
-      it "should hide in slack format" do
-        expected_result = """* Bug fixes *
-        - Scope 1:
-           - Add a new feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add another feature ([short_hash](/long_hash))
-        - Scope 1:
-           - Add one more ([short_hash](/long_hash))
-        """
+- Scope 1:
+   - Add a new feature ([short_hash](/long_hash))
+   - Add another feature ([short_hash](/long_hash))
+- Scope 1: Add one more ([short_hash](/long_hash))"""
 
         result = execute_lane_test(group_by_scope: true, format: 'slack')
 

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -564,8 +564,8 @@ describe Fastlane::Actions::ConventionalChangelogAction do
             expected_result = "# 1.0.2 (2019-05-25)\n\n"\
                               "### Features\n"\
                               "- **Announcements:** Feature with mixed case scope #{HASH_MARKDOWN}\n"\
-                              "- **cache:** Feature with lowercase scope #{HASH_MARKDOWN}\n"\
-                              "- **OFFLINE:** Feature with uppercase scope #{HASH_MARKDOWN}\n"\
+                              "- **Cache:** Feature with lowercase scope #{HASH_MARKDOWN}\n"\
+                              "- **Offline:** Feature with uppercase scope #{HASH_MARKDOWN}\n"\
                               "- **Schedule:** Feature with padded scope #{HASH_MARKDOWN}"
 
             result = execute_lane_test(group_by_scope: true)
@@ -576,8 +576,8 @@ describe Fastlane::Actions::ConventionalChangelogAction do
             expected_result = "1.0.2 (2019-05-25)\n\n"\
                               "Features:\n"\
                               "- Announcements: Feature with mixed case scope #{HASH_PLAIN}\n"\
-                              "- cache: Feature with lowercase scope #{HASH_PLAIN}\n"\
-                              "- OFFLINE: Feature with uppercase scope #{HASH_PLAIN}\n"\
+                              "- Cache: Feature with lowercase scope #{HASH_PLAIN}\n"\
+                              "- Offline: Feature with uppercase scope #{HASH_PLAIN}\n"\
                               "- Schedule: Feature with padded scope #{HASH_PLAIN}"
 
             result = execute_lane_test(group_by_scope: true, format: 'plain')
@@ -601,7 +601,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
           it "should group all case variations of the same scope together" do
             expected_result = "# 1.0.2 (2019-05-25)\n\n"\
                               "### Features\n"\
-                              "- **offline:**\n"\
+                              "- **Offline:**\n"\
                               "   - First offline feature #{HASH_MARKDOWN}\n"\
                               "   - Second offline feature #{HASH_MARKDOWN}\n"\
                               "   - Third offline feature #{HASH_MARKDOWN}\n"\
@@ -715,9 +715,9 @@ describe Fastlane::Actions::ConventionalChangelogAction do
           it "should map Cleanup and Refactor to canonical 'refactor' scope" do
             expected_result = "# 1.0.2 (2019-05-25)\n\n"\
                               "### Features\n"\
-                              "- **any:** Any other work #{HASH_MARKDOWN}\n"\
+                              "- **Any:** Any other work #{HASH_MARKDOWN}\n"\
                               "- **Cache:** Cache optimization #{HASH_MARKDOWN}\n"\
-                              "- **refactor:**\n"\
+                              "- **Refactor:**\n"\
                               "   - Refactor authentication module #{HASH_MARKDOWN}\n"\
                               "   - Refactor database layer #{HASH_MARKDOWN}\n"\
                               "   - Cleanup unused imports #{HASH_MARKDOWN}\n"\
@@ -739,7 +739,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
 
             expected_result = "# 1.0.2 (2019-05-25)\n\n"\
                               "### Features\n"\
-                              "- **refactor:**\n"\
+                              "- **Refactor:**\n"\
                               "   - Lowercase refactor #{HASH_MARKDOWN}\n"\
                               "   - Uppercase cleanup #{HASH_MARKDOWN}\n"\
                               "   - Mixed case refactor #{HASH_MARKDOWN}\n"\
@@ -768,6 +768,39 @@ describe Fastlane::Actions::ConventionalChangelogAction do
             expect do
               execute_lane_test(group_by_scope: true, sections: "invalid")
             end.to raise_error(FastlaneCore::Interface::FastlaneError, /value must be a Hash/)
+          end
+        end
+
+        describe "capitalized types" do
+          before do
+            commits = [
+              commit(type: 'Refactor', scope: 'Playlist', title: 'Rename PlaylistLocalService to PlaylistCache'),
+              commit(type: 'REFACTOR', scope: 'PlaylistRepository', title: 'Simplify playlist fetching logic'),
+              commit(type: 'Fix', scope: 'Cache', title: 'Improve cache mechanism'),
+              commit(type: 'FIX', scope: 'Offline', title: 'File downloads sometimes skips some files'),
+              commit(type: 'Feat', scope: 'Offline', title: 'Implement track download orchestration'),
+              commit(type: 'FEAT', scope: 'Schedule', title: 'Precache all playlist schedule media')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+            allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+          end
+
+          it "should recognize capitalized types and group them correctly" do
+            expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                              "### Features\n"\
+                              "- **Offline:** Implement track download orchestration #{HASH_MARKDOWN}\n"\
+                              "- **Schedule:** Precache all playlist schedule media #{HASH_MARKDOWN}\n"\
+                              "### Bug fixes\n"\
+                              "- **Cache:** Improve cache mechanism #{HASH_MARKDOWN}\n"\
+                              "- **Offline:** File downloads sometimes skips some files #{HASH_MARKDOWN}\n"\
+                              "### Code refactoring\n"\
+                              "- **Playlist:** Rename PlaylistLocalService to PlaylistCache #{HASH_MARKDOWN}\n"\
+                              "- **PlaylistRepository:** Simplify playlist fetching logic #{HASH_MARKDOWN}"
+
+            result = execute_lane_test(group_by_scope: true)
+
+            expect(result).to eq(expected_result)
           end
         end
       end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -565,9 +565,9 @@ describe Fastlane::Actions::ConventionalChangelogAction do
               # no_type is missing
             }
 
-            expect {
+            expect do
               execute_lane_test(group_by_scope: true, sections: custom_sections)
-            }.to raise_error(FastlaneCore::Interface::FastlaneError, /sections parameter must include a :no_type key/)
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, /sections parameter must include a :no_type key/)
           end
 
           it "should raise error when no_type section is empty" do
@@ -578,15 +578,15 @@ describe Fastlane::Actions::ConventionalChangelogAction do
               no_type: ""
             }
 
-            expect {
+            expect do
               execute_lane_test(group_by_scope: true, sections: custom_sections)
-            }.to raise_error(FastlaneCore::Interface::FastlaneError, /sections\[:no_type\] cannot be nil or empty/)
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, /sections\[:no_type\] cannot be nil or empty/)
           end
 
           it "should raise error when sections is not a hash" do
-            expect {
+            expect do
               execute_lane_test(group_by_scope: true, sections: "invalid")
-            }.to raise_error(FastlaneCore::Interface::FastlaneError, /value must be a Hash/)
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, /value must be a Hash/)
           end
         end
       end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -448,6 +448,148 @@ describe Fastlane::Actions::ConventionalChangelogAction do
           expect(result).to eq(expected_result)
         end
       end
+
+      # Edge case tests for grouping functionality
+      context "edge cases for grouping" do
+        describe "empty and whitespace scopes" do
+          before do
+            commits = [
+              commit(type: 'feat', scope: '', title: 'Feature with empty scope'),
+              commit(type: 'feat', scope: '   ', title: 'Feature with whitespace scope'),
+              commit(type: 'feat', scope: 'ValidScope', title: 'Feature with valid scope'),
+              commit(type: 'feat', title: 'Feature without scope')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+            allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+          end
+
+          it "should handle empty and whitespace scopes correctly in markdown format" do
+            expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                              "### Features\n"\
+                              "- **ValidScope:** Feature with valid scope #{HASH_MARKDOWN}\n"\
+                              "- **Other work:**\n"\
+                              "   - Feature with empty scope #{HASH_MARKDOWN}\n"\
+                              "   - Feature with whitespace scope #{HASH_MARKDOWN}\n"\
+                              "   - Feature without scope #{HASH_MARKDOWN}"
+
+            result = execute_lane_test(group_by_scope: true)
+            expect(result).to eq(expected_result)
+          end
+        end
+
+        describe "all merge commits in scope" do
+          before do
+            commits = [
+              "Merge branch 'feature'||long_hash|short_hash|Jiri Otahal|time",
+              "Merge pull request #123||long_hash|short_hash|Jiri Otahal|time",
+              commit(type: 'feat', scope: 'ValidScope', title: 'Valid feature')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+            allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+          end
+
+          it "should not create empty scope groups when all commits are merge commits" do
+            expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                              "### Features\n"\
+                              "- **ValidScope:** Valid feature #{HASH_MARKDOWN}"
+
+            result = execute_lane_test(group_by_scope: true)
+            expect(result).to eq(expected_result)
+          end
+        end
+
+        describe "mixed merge and regular commits in same scope" do
+          before do
+            commits = [
+              commit(type: 'feat', scope: 'MixedScope', title: 'First feature'),
+              "Merge branch 'feature'||long_hash|short_hash|Jiri Otahal|time",
+              commit(type: 'feat', scope: 'MixedScope', title: 'Second feature')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+            allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+          end
+
+          it "should filter out merge commits but keep regular commits in same scope" do
+            expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                              "### Features\n"\
+                              "- **MixedScope:**\n"\
+                              "   - First feature #{HASH_MARKDOWN}\n"\
+                              "   - Second feature #{HASH_MARKDOWN}"
+
+            result = execute_lane_test(group_by_scope: true)
+            expect(result).to eq(expected_result)
+          end
+        end
+
+        describe "scope with leading/trailing whitespace" do
+          before do
+            commits = [
+              commit(type: 'feat', scope: '  TrimScope  ', title: 'Feature with padded scope'),
+              commit(type: 'feat', scope: 'TrimScope', title: 'Feature with clean scope')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+            allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+          end
+
+          it "should group commits with trimmed scopes together" do
+            expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                              "### Features\n"\
+                              "- **TrimScope:**\n"\
+                              "   - Feature with padded scope #{HASH_MARKDOWN}\n"\
+                              "   - Feature with clean scope #{HASH_MARKDOWN}"
+
+            result = execute_lane_test(group_by_scope: true)
+            expect(result).to eq(expected_result)
+          end
+        end
+
+        describe "missing sections configuration" do
+          before do
+            commits = [
+              commit(type: 'feat', scope: 'TestScope', title: 'Test feature')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+            allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+          end
+
+          it "should raise error when no_type section is missing" do
+            # Test with sections that don't include no_type
+            custom_sections = {
+              feat: "Features",
+              fix: "Bug fixes"
+              # no_type is missing
+            }
+
+            expect {
+              execute_lane_test(group_by_scope: true, sections: custom_sections)
+            }.to raise_error(FastlaneCore::Interface::FastlaneError, /sections parameter must include a :no_type key/)
+          end
+
+          it "should raise error when no_type section is empty" do
+            # Test with empty no_type section
+            custom_sections = {
+              feat: "Features",
+              fix: "Bug fixes",
+              no_type: ""
+            }
+
+            expect {
+              execute_lane_test(group_by_scope: true, sections: custom_sections)
+            }.to raise_error(FastlaneCore::Interface::FastlaneError, /sections\[:no_type\] cannot be nil or empty/)
+          end
+
+          it "should raise error when sections is not a hash" do
+            expect {
+              execute_lane_test(group_by_scope: true, sections: "invalid")
+            }.to raise_error(FastlaneCore::Interface::FastlaneError, /value must be a Hash/)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -697,6 +697,60 @@ describe Fastlane::Actions::ConventionalChangelogAction do
             end.to raise_error(FastlaneCore::Interface::FastlaneError, /sections parameter must include a :no_type key/)
           end
 
+        describe "semantic scope mapping" do
+          before do
+            commits = [
+              commit(type: 'feat', scope: 'Refactor', title: 'Refactor authentication module'),
+              commit(type: 'feat', scope: 'REFACTOR', title: 'Refactor database layer'),
+              commit(type: 'feat', scope: 'Cleanup', title: 'Cleanup unused imports'),
+              commit(type: 'feat', scope: 'CLEANUP', title: 'Cleanup test files'),
+              commit(type: 'feat', scope: 'Any', title: 'Any other work'),
+              commit(type: 'feat', scope: 'Cache', title: 'Cache optimization')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+            allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+          end
+
+          it "should map Cleanup and Refactor to canonical 'refactor' scope" do
+            expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                              "### Features\n"\
+                              "- **any:** Any other work #{HASH_MARKDOWN}\n"\
+                              "- **Cache:** Cache optimization #{HASH_MARKDOWN}\n"\
+                              "- **refactor:**\n"\
+                              "   - Refactor authentication module #{HASH_MARKDOWN}\n"\
+                              "   - Refactor database layer #{HASH_MARKDOWN}\n"\
+                              "   - Cleanup unused imports #{HASH_MARKDOWN}\n"\
+                              "   - Cleanup test files #{HASH_MARKDOWN}"
+
+            result = execute_lane_test(group_by_scope: true)
+            expect(result).to eq(expected_result)
+          end
+
+          it "should handle mixed case variations of Cleanup and Refactor" do
+            commits = [
+              commit(type: 'feat', scope: 'refactor', title: 'Lowercase refactor'),
+              commit(type: 'feat', scope: 'CLEANUP', title: 'Uppercase cleanup'),
+              commit(type: 'feat', scope: 'Refactor', title: 'Mixed case refactor'),
+              commit(type: 'feat', scope: 'cleanup', title: 'Lowercase cleanup')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+
+            expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                              "### Features\n"\
+                              "- **refactor:**\n"\
+                              "   - Lowercase refactor #{HASH_MARKDOWN}\n"\
+                              "   - Uppercase cleanup #{HASH_MARKDOWN}\n"\
+                              "   - Mixed case refactor #{HASH_MARKDOWN}\n"\
+                              "   - Lowercase cleanup #{HASH_MARKDOWN}"
+
+            result = execute_lane_test(group_by_scope: true)
+            expect(result).to eq(expected_result)
+          end
+        end
+
+
           it "should raise error when no_type section is empty" do
             # Test with empty no_type section
             custom_sections = {

--- a/spec/conventional_changelog_spec.rb
+++ b/spec/conventional_changelog_spec.rb
@@ -370,7 +370,7 @@ describe Fastlane::Actions::ConventionalChangelogAction do
           allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
         end
 
-        it "should group by type and then by scope" do
+        it "should group by type and then by scope, sorted alphabetically" do
           expected_result = "# 1.0.2 (2019-05-25)\n\n"\
                             "### Features\n"\
                             "- **Scope 1:**\n"\
@@ -378,10 +378,10 @@ describe Fastlane::Actions::ConventionalChangelogAction do
                             "   - Add another feature #{HASH_MARKDOWN}\n"\
                             "- **Scope 2:** Add one more feature #{HASH_MARKDOWN}\n"\
                             "### Bug fixes\n"\
-                            "- **Scope 2:** Add 1 more feature #{HASH_MARKDOWN}\n"\
                             "- **Scope 1:**\n"\
                             "   - Add 2 more feature #{HASH_MARKDOWN}\n"\
-                            "   - Add 3 more feature #{HASH_MARKDOWN}"\
+                            "   - Add 3 more feature #{HASH_MARKDOWN}\n"\
+                            "- **Scope 2:** Add 1 more feature #{HASH_MARKDOWN}"
 
 
           result = execute_lane_test(group_by_scope: true)
@@ -541,6 +541,133 @@ describe Fastlane::Actions::ConventionalChangelogAction do
                               "- **TrimScope:**\n"\
                               "   - Feature with padded scope #{HASH_MARKDOWN}\n"\
                               "   - Feature with clean scope #{HASH_MARKDOWN}"
+
+            result = execute_lane_test(group_by_scope: true)
+            expect(result).to eq(expected_result)
+          end
+        end
+
+        describe "scope case normalization" do
+          before do
+            commits = [
+              commit(type: 'feat', scope: 'cache', title: 'Feature with lowercase scope'),
+              commit(type: 'feat', scope: 'OFFLINE', title: 'Feature with uppercase scope'),
+              commit(type: 'feat', scope: 'Announcements', title: 'Feature with mixed case scope'),
+              commit(type: 'feat', scope: '  Schedule  ', title: 'Feature with padded scope')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+            allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+          end
+
+          it "should group case-insensitive scopes together and sort alphabetically in markdown format" do
+            expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                              "### Features\n"\
+                              "- **Announcements:** Feature with mixed case scope #{HASH_MARKDOWN}\n"\
+                              "- **cache:** Feature with lowercase scope #{HASH_MARKDOWN}\n"\
+                              "- **OFFLINE:** Feature with uppercase scope #{HASH_MARKDOWN}\n"\
+                              "- **Schedule:** Feature with padded scope #{HASH_MARKDOWN}"
+
+            result = execute_lane_test(group_by_scope: true)
+            expect(result).to eq(expected_result)
+          end
+
+          it "should group case-insensitive scopes together and sort alphabetically in plain format" do
+            expected_result = "1.0.2 (2019-05-25)\n\n"\
+                              "Features:\n"\
+                              "- Announcements: Feature with mixed case scope #{HASH_PLAIN}\n"\
+                              "- cache: Feature with lowercase scope #{HASH_PLAIN}\n"\
+                              "- OFFLINE: Feature with uppercase scope #{HASH_PLAIN}\n"\
+                              "- Schedule: Feature with padded scope #{HASH_PLAIN}"
+
+            result = execute_lane_test(group_by_scope: true, format: 'plain')
+            expect(result).to eq(expected_result)
+          end
+        end
+
+        describe "scope case normalization with duplicates" do
+          before do
+            commits = [
+              commit(type: 'feat', scope: 'offline', title: 'First offline feature'),
+              commit(type: 'feat', scope: 'OFFLINE', title: 'Second offline feature'),
+              commit(type: 'feat', scope: 'Offline', title: 'Third offline feature'),
+              commit(type: 'feat', scope: '  offline  ', title: 'Fourth offline feature')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+            allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+          end
+
+          it "should group all case variations of the same scope together" do
+            expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                              "### Features\n"\
+                              "- **offline:**\n"\
+                              "   - First offline feature #{HASH_MARKDOWN}\n"\
+                              "   - Second offline feature #{HASH_MARKDOWN}\n"\
+                              "   - Third offline feature #{HASH_MARKDOWN}\n"\
+                              "   - Fourth offline feature #{HASH_MARKDOWN}"
+
+            result = execute_lane_test(group_by_scope: true)
+            expect(result).to eq(expected_result)
+          end
+        end
+
+        describe "alphabetical scope sorting" do
+          before do
+            commits = [
+              commit(type: 'feat', scope: 'Zebra', title: 'Feature Z'),
+              commit(type: 'feat', scope: 'Apple', title: 'Feature A'),
+              commit(type: 'feat', scope: 'Monkey', title: 'Feature M'),
+              commit(type: 'feat', scope: 'Banana', title: 'Feature B')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+            allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+          end
+
+          it "should sort scopes alphabetically in markdown format" do
+            expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                              "### Features\n"\
+                              "- **Apple:** Feature A #{HASH_MARKDOWN}\n"\
+                              "- **Banana:** Feature B #{HASH_MARKDOWN}\n"\
+                              "- **Monkey:** Feature M #{HASH_MARKDOWN}\n"\
+                              "- **Zebra:** Feature Z #{HASH_MARKDOWN}"
+
+            result = execute_lane_test(group_by_scope: true)
+            expect(result).to eq(expected_result)
+          end
+
+          it "should sort scopes alphabetically in plain format" do
+            expected_result = "1.0.2 (2019-05-25)\n\n"\
+                              "Features:\n"\
+                              "- Apple: Feature A #{HASH_PLAIN}\n"\
+                              "- Banana: Feature B #{HASH_PLAIN}\n"\
+                              "- Monkey: Feature M #{HASH_PLAIN}\n"\
+                              "- Zebra: Feature Z #{HASH_PLAIN}"
+
+            result = execute_lane_test(group_by_scope: true, format: 'plain')
+            expect(result).to eq(expected_result)
+          end
+        end
+
+        describe "alphabetical scope sorting with fallback scope" do
+          before do
+            commits = [
+              commit(type: 'feat', scope: 'Zebra', title: 'Feature Z'),
+              commit(type: 'feat', title: 'Feature without scope'),
+              commit(type: 'feat', scope: 'Apple', title: 'Feature A')
+            ]
+
+            allow(Fastlane::Actions::ConventionalChangelogAction).to receive(:get_commits_from_hash).and_return(commits)
+            allow(Date).to receive(:today).and_return(Date.new(2019, 5, 25))
+          end
+
+          it "should sort named scopes alphabetically and put fallback scope last" do
+            expected_result = "# 1.0.2 (2019-05-25)\n\n"\
+                              "### Features\n"\
+                              "- **Apple:** Feature A #{HASH_MARKDOWN}\n"\
+                              "- **Zebra:** Feature Z #{HASH_MARKDOWN}\n"\
+                              "- **Other work:** Feature without scope #{HASH_MARKDOWN}"
 
             result = execute_lane_test(group_by_scope: true)
             expect(result).to eq(expected_result)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,11 @@ require 'fastlane' # to import the Action super class
 require 'fastlane/plugin/semantic_release' # import the actual plugin
 
 Fastlane.load_actions # load other actions (in case your plugin calls other actions or shared values)
+
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.max_formatted_output_length = 1000
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ Fastlane.load_actions # load other actions (in case your plugin calls other acti
 
 
 RSpec.configure do |config|
-  config.expect_with :rspec do |expectations|
+  config.expect_with(:rspec) do |expectations|
     expectations.max_formatted_output_length = 1000
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,6 @@ require 'fastlane/plugin/semantic_release' # import the actual plugin
 
 Fastlane.load_actions # load other actions (in case your plugin calls other actions or shared values)
 
-
 RSpec.configure do |config|
   config.expect_with(:rspec) do |expectations|
     expectations.max_formatted_output_length = 1000


### PR DESCRIPTION
Copy of:
- https://github.com/xotahal/fastlane-plugin-semantic_release/pull/50

The idea is to have more control while they accept it